### PR TITLE
[PDD-239] Add method to order using replication_key and primary keys

### DIFF
--- a/tap_suiteql/query_builder.py
+++ b/tap_suiteql/query_builder.py
@@ -48,11 +48,20 @@ class QueryBuilder:
         where_statement += " and ".join(where_clauses)
         return where_statement
 
+    def _build_order_statement(self):
+        order_statement = "order by "
+        if self.stream.replication_key:
+            order_statement += f"{self.stream.replication_key},{self.stream.primary_keys[0]}"
+        else:
+            order_statement += f"{self.stream.primary_keys[0]}"
+        return order_statement
+
     def query(self) -> str:
         select_statement = self._build_select_statement()
         from_statement = self._build_from_statement()
         where_statement = self._build_where_statement()
+        order_statement = self._build_order_statement()
 
-        query = f"{select_statement} {from_statement} {where_statement}".strip()
+        query = f"{select_statement} {from_statement} {where_statement} {order_statement}".strip()
 
         return query

--- a/tap_suiteql/tests/test_query_builder.py
+++ b/tap_suiteql/tests/test_query_builder.py
@@ -4,12 +4,14 @@ from tap_suiteql.query_builder import QueryBuilder
 class DummyStream:
     name = "dummy"
     entity_name = ""
+    primary_keys = ["col_id"]
     replication_key = "replication_key_col"
     skip_attributes = []
     stream_type = None
     schema = {
         "type": "object",
         "properties": {
+            "col_id": {},
             "col_1": {},
             "col_2": {},
             "date_col": {"format": "date-time"},
@@ -21,12 +23,14 @@ class DummyStream:
 class DummyStreamWithoutReplicationKey:
     name = "dummy_without_replication_key"
     entity_name = ""
+    primary_keys = ["col_id"]
     skip_attributes = []
     replication_key = None
     stream_type = None
     schema = {
         "type": "object",
         "properties": {
+            "col_id": {},
             "col_1": {},
             "col_2": {},
             "date_col": {"format": "date-time"},
@@ -37,12 +41,14 @@ class DummyStreamWithoutReplicationKey:
 class DummyStreamTransaction:
     name = "dummy"
     entity_name = "dummy_transaction"
+    primary_keys = ["col_id"]
     replication_key = "replication_key_col"
     stream_type = "CustDummy"
     skip_attributes = []
     schema = {
         "type": "object",
         "properties": {
+            "col_id": {},
             "col_1": {},
             "col_2": {},
             "date_col": {"format": "date-time"},
@@ -52,21 +58,21 @@ class DummyStreamTransaction:
 
 
 def test_sql_builder_with_replication_key():
-    expected = """select col_1,col_2,TO_CHAR(date_col, 'YYYY-MM-DD\"T\"HH24:MI:SS') date_col,TO_CHAR(replication_key_col, 'YYYY-MM-DD\"T\"HH24:MI:SS') replication_key_col from dummy where 1=1 and replication_key_col >= TO_DATE(:replication_key_col, 'YYYY-MM-DD\"T\"HH24:MI:SS')"""  # noqa:E501
+    expected = """select col_id,col_1,col_2,TO_CHAR(date_col, 'YYYY-MM-DD\"T\"HH24:MI:SS') date_col,TO_CHAR(replication_key_col, 'YYYY-MM-DD\"T\"HH24:MI:SS') replication_key_col from dummy where 1=1 and replication_key_col >= TO_DATE(:replication_key_col, 'YYYY-MM-DD\"T\"HH24:MI:SS') order by replication_key_col,col_id"""  # noqa:E501
     query = QueryBuilder(DummyStream).query()
 
     assert expected == query
 
 
 def test_sql_builder_without_replication_key():
-    expected = """select col_1,col_2,TO_CHAR(date_col, 'YYYY-MM-DD\"T\"HH24:MI:SS') date_col from dummy_without_replication_key where 1=1"""  # noqa:E501
+    expected = """select col_id,col_1,col_2,TO_CHAR(date_col, 'YYYY-MM-DD\"T\"HH24:MI:SS') date_col from dummy_without_replication_key where 1=1 order by col_id"""  # noqa:E501
     query = QueryBuilder(DummyStreamWithoutReplicationKey).query()
 
     assert expected == query
 
 
 def test_sql_builder_from_transaction():
-    expected = """select col_1,col_2,TO_CHAR(date_col, 'YYYY-MM-DD\"T\"HH24:MI:SS') date_col,TO_CHAR(replication_key_col, 'YYYY-MM-DD\"T\"HH24:MI:SS') replication_key_col from dummy_transaction where 1=1 and replication_key_col >= TO_DATE(:replication_key_col, 'YYYY-MM-DD\"T\"HH24:MI:SS') and type = 'CustDummy'"""  # noqa:E501
+    expected = """select col_id,col_1,col_2,TO_CHAR(date_col, 'YYYY-MM-DD\"T\"HH24:MI:SS') date_col,TO_CHAR(replication_key_col, 'YYYY-MM-DD\"T\"HH24:MI:SS') replication_key_col from dummy_transaction where 1=1 and replication_key_col >= TO_DATE(:replication_key_col, 'YYYY-MM-DD\"T\"HH24:MI:SS') and type = 'CustDummy' order by replication_key_col,col_id"""  # noqa:E501
     query = QueryBuilder(DummyStreamTransaction).query()
 
     assert expected == query


### PR DESCRIPTION
Para resolvermos o problema que estávamos tendo com a extração do netsuite, estamos adicionando a ordenação na consulta tanto por `replication_key` quanto por `primary_keys`, sendo que quando a extração for do tipo `FULL_TABLE` a ordenação será apenas através da `primary_keys`.