### PR TITLE
[PDD-239] Adjust _build_order_statement method to consider cases where there is no primary_key

### DIFF
--- a/tap_suiteql/query_builder.py
+++ b/tap_suiteql/query_builder.py
@@ -50,13 +50,14 @@ class QueryBuilder:
 
     def _build_order_statement(self):
         order_statement = None
+
         if self.stream.replication_key and self.stream.primary_keys:
-            order_statement = f"order by {self.stream.replication_key},{self.stream.primary_keys[0]}"
-        
+            order_statement = (
+                f"order by {self.stream.replication_key},{self.stream.primary_keys[0]}"
+            )
         elif self.stream.replication_key is None and self.stream.primary_keys:
             order_statement = f"order by {self.stream.primary_keys[0]}"
-        
-        return '' if order_statement is None else order_statement
+        return "" if order_statement is None else order_statement
 
     def query(self) -> str:
         select_statement = self._build_select_statement()
@@ -64,6 +65,11 @@ class QueryBuilder:
         where_statement = self._build_where_statement()
         order_statement = self._build_order_statement()
 
-        query = f"{select_statement} {from_statement} {where_statement} {order_statement}".strip()
+        query = f"""
+            {select_statement}
+            {from_statement}
+            {where_statement}
+            {order_statement}
+        """.strip()
 
         return query

--- a/tap_suiteql/query_builder.py
+++ b/tap_suiteql/query_builder.py
@@ -49,12 +49,14 @@ class QueryBuilder:
         return where_statement
 
     def _build_order_statement(self):
-        order_statement = "order by "
-        if self.stream.replication_key:
-            order_statement += f"{self.stream.replication_key},{self.stream.primary_keys[0]}"
-        else:
-            order_statement += f"{self.stream.primary_keys[0]}"
-        return order_statement
+        order_statement = None
+        if self.stream.replication_key and self.stream.primary_keys:
+            order_statement = f"order by {self.stream.replication_key},{self.stream.primary_keys[0]}"
+        
+        elif self.stream.replication_key is None and self.stream.primary_keys:
+            order_statement = f"order by {self.stream.primary_keys[0]}"
+        
+        return '' if order_statement is None else order_statement
 
     def query(self) -> str:
         select_statement = self._build_select_statement()

--- a/tap_suiteql/tap.py
+++ b/tap_suiteql/tap.py
@@ -1,9 +1,9 @@
 """suiteql tap class."""
 import json
 import os
-from typing import List
+from typing import Any, List
 
-from singer_sdk import Stream, Tap
+from singer_sdk import Tap
 from singer_sdk import typing as th
 
 from tap_suiteql.query_builder import QueryBuilder  # JSON schema typing helpers
@@ -16,12 +16,12 @@ from tap_suiteql.streams import (
     CustomlistGpyReadjustmentindexStream,
     CustomrecordGpyStatuschangeOrderStream,
     InvoiceStream,
+    ItemStream,
     SubscriptionChangeOrderStream,
     SubscriptionLineStream,
     SubscriptionPlanStream,
     SubscriptionPriceIntervalStream,
     SubscriptionStream,
-    ItemStream,
 )
 
 STREAM_TYPES = {
@@ -85,9 +85,9 @@ class Tapsuiteql(Tap):
         ),
     ).to_dict()
 
-    def get_stream_types(self) -> List[Stream]:
+    def get_stream_types(self) -> List[Any]:
 
-        stream_types = []
+        stream_types: Any = []
         select_statement = json.loads(os.environ.get("TAP_SUITEQL__SELECT", '["*.*"]'))
 
         if select_statement == ["*.*"]:
@@ -99,10 +99,10 @@ class Tapsuiteql(Tap):
 
         return stream_types
 
-    def discover_streams(self) -> List[Stream]:
+    def discover_streams(self) -> List[Any]:
         """Return a list of discovered streams."""
 
-        stream_classes: List[Stream] = []
+        stream_classes: List[Any] = []
 
         for stream_class in self.get_stream_types():
             schema = SchemaBuilder(stream_class(tap=self)).schema()

--- a/tap_suiteql/tests/test_query_builder.py
+++ b/tap_suiteql/tests/test_query_builder.py
@@ -38,6 +38,23 @@ class DummyStreamWithoutReplicationKey:
     }
 
 
+class DummyStreamWithoutPrimaryKeys:
+    name = "dummy_without_primary_keys"
+    entity_name = ""
+    skip_attributes = []
+    primary_keys = None
+    replication_key = None
+    stream_type = None
+    schema = {
+        "type": "object",
+        "properties": {
+            "col_1": {},
+            "col_2": {},
+            "date_col": {"format": "date-time"},
+        },
+    }
+
+
 class DummyStreamTransaction:
     name = "dummy"
     entity_name = "dummy_transaction"
@@ -58,21 +75,39 @@ class DummyStreamTransaction:
 
 
 def test_sql_builder_with_replication_key():
-    expected = """select col_id,col_1,col_2,TO_CHAR(date_col, 'YYYY-MM-DD\"T\"HH24:MI:SS') date_col,TO_CHAR(replication_key_col, 'YYYY-MM-DD\"T\"HH24:MI:SS') replication_key_col from dummy where 1=1 and replication_key_col >= TO_DATE(:replication_key_col, 'YYYY-MM-DD\"T\"HH24:MI:SS') order by replication_key_col,col_id"""  # noqa:E501
+    expected = """select col_id,col_1,col_2,TO_CHAR(date_col, 'YYYY-MM-DD\"T\"HH24:MI:SS') date_col,TO_CHAR(replication_key_col, 'YYYY-MM-DD\"T\"HH24:MI:SS') replication_key_col
+            from dummy
+            where 1=1 and replication_key_col >= TO_DATE(:replication_key_col, 'YYYY-MM-DD\"T\"HH24:MI:SS')
+            order by replication_key_col,col_id"""  # noqa:E501
     query = QueryBuilder(DummyStream).query()
 
     assert expected == query
 
 
 def test_sql_builder_without_replication_key():
-    expected = """select col_id,col_1,col_2,TO_CHAR(date_col, 'YYYY-MM-DD\"T\"HH24:MI:SS') date_col from dummy_without_replication_key where 1=1 order by col_id"""  # noqa:E501
+    expected = """select col_id,col_1,col_2,TO_CHAR(date_col, 'YYYY-MM-DD\"T\"HH24:MI:SS') date_col
+            from dummy_without_replication_key
+            where 1=1
+            order by col_id"""  # noqa:E501
     query = QueryBuilder(DummyStreamWithoutReplicationKey).query()
 
     assert expected == query
 
 
+def test_sql_builder_without_primary_keys():
+    expected = """select col_1,col_2,TO_CHAR(date_col, 'YYYY-MM-DD\"T\"HH24:MI:SS') date_col
+            from dummy_without_primary_keys
+            where 1=1"""  # noqa:E501
+    query = QueryBuilder(DummyStreamWithoutPrimaryKeys).query()
+
+    assert expected == query
+
+
 def test_sql_builder_from_transaction():
-    expected = """select col_id,col_1,col_2,TO_CHAR(date_col, 'YYYY-MM-DD\"T\"HH24:MI:SS') date_col,TO_CHAR(replication_key_col, 'YYYY-MM-DD\"T\"HH24:MI:SS') replication_key_col from dummy_transaction where 1=1 and replication_key_col >= TO_DATE(:replication_key_col, 'YYYY-MM-DD\"T\"HH24:MI:SS') and type = 'CustDummy' order by replication_key_col,col_id"""  # noqa:E501
+    expected = """select col_id,col_1,col_2,TO_CHAR(date_col, 'YYYY-MM-DD\"T\"HH24:MI:SS') date_col,TO_CHAR(replication_key_col, 'YYYY-MM-DD\"T\"HH24:MI:SS') replication_key_col
+            from dummy_transaction
+            where 1=1 and replication_key_col >= TO_DATE(:replication_key_col, 'YYYY-MM-DD\"T\"HH24:MI:SS') and type = 'CustDummy'
+            order by replication_key_col,col_id"""  # noqa:E501
     query = QueryBuilder(DummyStreamTransaction).query()
 
     assert expected == query


### PR DESCRIPTION
Ao observar a execução da DAG de extração do netsuite, notou-se um erro na taks `el_netsuite_raw_change_order_line`. A causa do erro se deve ao fato dessa entidade não ter `primary_keys` enquanto o método  `_build_order_statement` estava considerando a existência desta variável para todas as entidades.

Neste PR estou ajustando o método para considerar a não existência da variável `primary_keys`