### PR TITLE
[PDD-308] Add replication_key from SubscriptionLineStream

### DIFF
--- a/tap_suiteql/streams.py
+++ b/tap_suiteql/streams.py
@@ -42,6 +42,7 @@ class SubscriptionLineStream(suiteqlStream):
     metadata_path = "/record/v1/metadata-catalog/subscriptionline"
     primary_keys = ["id"]
     skip_attributes = ["links"]
+    replication_key = "lastmodifieddate"
 
 
 class SubscriptionPriceIntervalStream(suiteqlStream):


### PR DESCRIPTION
A variável `replication_key=lastmodifieddate` tinha sido removida pois a extração da SubscriptionLineStream passou a ser FULL_TABLE. Com a remoção da variável, o campo `lastmodifieddate` passou a ficar com valor NULL, esse PR está revertendo essa alteração para termos os valores para esse campo obtidos do netsuite.

A extração continuará FULL_TABLE uma vez que não será passado a flag `--state-id` no comando elt do meltano.