### PR TITLE
chore(tap-suitql): Change year from filter in query builder

### DIFF
--- a/tap_suiteql/query_builder.py
+++ b/tap_suiteql/query_builder.py
@@ -41,7 +41,7 @@ class QueryBuilder:
             self.stream.year_date_field
         ):  # Filter added due to the limit of 100 thousand records that the Sensedata API returns # noqa:E501
             where_clauses.append(
-                f"TO_CHAR({self.stream.year_date_field}, 'YYYY') >= 2023 and {self.stream.year_date_field} < ADD_MONTHS(SYSDATE, 3)"  # noqa:E501
+                f"TO_CHAR({self.stream.year_date_field}, 'YYYY') >= 2024 and {self.stream.year_date_field} < ADD_MONTHS(SYSDATE, 3)"  # noqa:E501
             )
 
         if self.stream.replication_key:

--- a/tap_suiteql/tests/test_query_builder.py
+++ b/tap_suiteql/tests/test_query_builder.py
@@ -139,7 +139,7 @@ def test_sql_builder_from_transaction():
 def test_sql_builder_with_filter():
     expected = """select col_id,col_1,col_2,TO_CHAR(year_date_field, 'YYYY-MM-DD\"T\"HH24:MI:SS') year_date_field
             from dummy_with_stream
-            where 1=1 and TO_CHAR(year_date_field, 'YYYY') >= 2023 and year_date_field < ADD_MONTHS(SYSDATE, 3)
+            where 1=1 and TO_CHAR(year_date_field, 'YYYY') >= 2024 and year_date_field < ADD_MONTHS(SYSDATE, 3)
             order by col_id"""  # noqa:E501
 
     query = QueryBuilder(DummyStreamWithFilter).query()


### PR DESCRIPTION
Testando local esse PR, trouxe os resultados esperados e um total de 38mil linhas.

![image](https://github.com/gupy-io/tap-suiteql/assets/111759542/90dec931-e152-41ae-b0e6-2f9f4bd794fd)
